### PR TITLE
Add parsing issue number from branch name

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -2,8 +2,8 @@ name: 'Issue Pull Request'
 description: 'Creates pull request based on issue.'
 inputs:
   issue:
-    description: 'Number of issue which title used to create pull request.'
-    required: true
+    description: 'Number of issue which title used to create pull request or regex from config will be used to determine issue number based on branch name.'
+    required: false
   base:
     description: 'Base branch of new pull request.'
     default: master
@@ -31,6 +31,7 @@ inputs:
     description: 'Path to file or config as value with generate settings. (Possible representation types: "Json" or "Yaml".)'
     default: |
       comment: 'Linked Issue: #{number}.'
+      issueBranchRegex: '(?<=issue-)(\d*?)(?=-)'
     required: true
   context:
     description: 'Context can be specific value or file path, and can be accessed in text formatting context. (Possible representation types: "Json" or "Yaml".)'

--- a/dist/index.js
+++ b/dist/index.js
@@ -3762,6 +3762,7 @@ exports.createIssuePullRequest = void 0;
 const utility = __importStar(__webpack_require__(880));
 function createIssuePullRequest(owner, repo, number, base, head, body, link, config, context) {
     return __awaiter(this, void 0, void 0, function* () {
+        number = getIssueNumber(number, head, config);
         const issue = yield utility.getIssue(owner, repo, number);
         const pullRequest = yield createPullRequest(owner, repo, issue.title, body ? issue.body : '', base, head);
         if (link) {
@@ -3800,6 +3801,16 @@ function createIssueComment(owner, repo, number, body) {
             body: body
         });
     });
+}
+function getIssueNumber(number, head, config) {
+    if (number === '') {
+        const matches = head.match(new RegExp(config.issueBranchRegex, 'g'));
+        if (matches != null && matches.length > 0) {
+            return matches[0];
+        }
+        throw `No matches found in specified head branch: '${head}'.`;
+    }
+    return number;
 }
 
 
@@ -5055,7 +5066,7 @@ run();
 function run() {
     return __awaiter(this, void 0, void 0, function* () {
         try {
-            const issue = core.getInput('issue', { required: true });
+            const issue = core.getInput('issue');
             const base = core.getInput('base', { required: true });
             const head = core.getInput('head', { required: true });
             const body = core.getInput('body', { required: true }) === 'true';

--- a/src/action.ts
+++ b/src/action.ts
@@ -1,6 +1,8 @@
 import * as utility from './utility'
 
 export async function createIssuePullRequest(owner: string, repo: string, number: string, base: string, head: string, body: boolean, link: boolean, config: any, context: any): Promise<string> {
+  number = getIssueNumber(number, head, config)
+
   const issue = await utility.getIssue(owner, repo, number)
   const pullRequest = await createPullRequest(owner, repo, issue.title, body ? issue.body : '', base, head)
 
@@ -43,4 +45,18 @@ async function createIssueComment(owner: string, repo: string, number: string, b
   await octokit.request(`POST /repos/${owner}/${repo}/issues/${number}/comments`, {
     body: body
   })
+}
+
+function getIssueNumber(number: string, head: string, config: any): string {
+  if (number === '') {
+    const matches = head.match(new RegExp(config.issueBranchRegex, 'g'))
+
+    if (matches != null && matches.length > 0) {
+      return matches[0]
+    }
+
+    throw `No matches found in specified head branch: '${head}'.`
+  }
+
+  return number
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -6,7 +6,7 @@ run()
 
 async function run(): Promise<void> {
   try {
-    const issue = core.getInput('issue', {required: true})
+    const issue = core.getInput('issue')
     const base = core.getInput('base', {required: true})
     const head = core.getInput('head', {required: true})
     const body = core.getInput('body', {required: true}) === 'true'


### PR DESCRIPTION
Add `issueBranchRegex` to config which used when no issue number specified to parse issue number from branch name. Default is `(?<=issue-)(\d*?)(?=-)`.